### PR TITLE
8 ratemyprofessor

### DIFF
--- a/src/main/java/gateways/RateMyProf.java
+++ b/src/main/java/gateways/RateMyProf.java
@@ -11,11 +11,20 @@ import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.Map;
 
-
+/**
+ * A gateway for the RateMyProf API that has public static methods for getting the number of professors associated
+ * with UofT on the RateMyProf database, the number of pages of professors, and the professors mapped with their score
+ * provided that their score is a defined number
+ */
 public class RateMyProf {
     private static Map<String, String> professors;
 
-
+    /**
+     * Make an HTTP Get request to the RateMyProf database and return the data as a JSONObject
+     * @param page the page to query from the RateMyProf database
+     * @return JSON object containing the response
+     * @throws IOException if the HTTP request fails
+     */
     private static JSONObject request(String page) throws IOException {
         // Create a URL object and make a GET request
         String url = String.format("https://www.ratemyprofessors.com/filter/professor/?&page=%s&filter=teacherlastname_sort_s+asc&query=*%%3A*&queryoption=TEACHER&queryBy=schoolId&sid=1484", page);
@@ -39,26 +48,31 @@ public class RateMyProf {
      * Find the number of professors currently stored by rate my prof
      * @return the number of professors as an int
      */
-    private static int getNumberProfessors() throws IOException {
+    public static int getNumberProfessors() throws IOException {
         return (int) request("1").get("searchResultsTotal");
     }
 
-    private static int getNumberPages() throws IOException {
+    /**
+     * Calculate the maximum number of pages of professors in the UofT RateMyProf database using the number of professors
+     * @return an int of the number of pages
+     * @throws IOException if the HTTP request fails
+     */
+    public static int getNumberPages() throws IOException {
         return (getNumberProfessors() / 20) + 1;
     }
 
     /**
      * Return a HashMap mapping professors to their RateMyProf score as a Double
      * The keys are of String type and follow the format: "[first name] [last name], [department]"
-     * @param pages
-     * @return
-     * @throws IOException
+     * @param pages the number of pages to check for professors (conservative overestimate)
+     * @return HashMap mapping professors to their RateMyProf score as a Double
+     * @throws IOException if the HTTP request fails
      */
-    private static Map<String, Double> getProfessors(int pages) throws IOException {
+    public static Map<String, Double> getProfessors(int pages) throws IOException {
         HashMap<String, Double> professors = new HashMap<>();
 
         // iterate through each page
-        for (int i = 0; i <= pages; i++) {
+        for (int i = 1; i <= pages; i++) {
             JSONObject data = request(String.valueOf(i));
             JSONArray professor_list = data.getJSONArray("professors");
 
@@ -76,17 +90,5 @@ public class RateMyProf {
             }
         }
         return professors;
-    }
-
-
-    public static void main(String[] args) throws IOException {
-        JSONObject data = request("199");
-        System.out.println(data);
-        System.out.println(getNumberProfessors());
-        System.out.println(getNumberPages());
-        JSONArray profs = data.getJSONArray("professors");
-        System.out.println(profs.length());
-        System.out.println(getProfessors(getNumberPages()));
-
     }
 }

--- a/src/main/java/gateways/RateMyProf.java
+++ b/src/main/java/gateways/RateMyProf.java
@@ -1,0 +1,92 @@
+package gateways;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class RateMyProf {
+    private static Map<String, String> professors;
+
+
+    private static JSONObject request(String page) throws IOException {
+        // Create a URL object and make a GET request
+        String url = String.format("https://www.ratemyprofessors.com/filter/professor/?&page=%s&filter=teacherlastname_sort_s+asc&query=*%%3A*&queryoption=TEACHER&queryBy=schoolId&sid=1484", page);
+        URL api = new URL(url);
+        URLConnection con = api.openConnection();
+
+        // Read the data return and store it in a String
+        BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuilder content = new StringBuilder();
+        while ((inputLine = in.readLine()) != null) {
+            content.append(inputLine);
+        }
+        in.close();
+
+        // Parse the returned JSON into a JSON object
+        return new JSONObject(content.toString());
+    }
+
+    /**
+     * Find the number of professors currently stored by rate my prof
+     * @return the number of professors as an int
+     */
+    private static int getNumberProfessors() throws IOException {
+        return (int) request("1").get("searchResultsTotal");
+    }
+
+    private static int getNumberPages() throws IOException {
+        return (getNumberProfessors() / 20) + 1;
+    }
+
+    /**
+     * Return a HashMap mapping professors to their RateMyProf score as a Double
+     * The keys are of String type and follow the format: "[first name] [last name], [department]"
+     * @param pages
+     * @return
+     * @throws IOException
+     */
+    private static Map<String, Double> getProfessors(int pages) throws IOException {
+        HashMap<String, Double> professors = new HashMap<>();
+
+        // iterate through each page
+        for (int i = 0; i <= pages; i++) {
+            JSONObject data = request(String.valueOf(i));
+            JSONArray professor_list = data.getJSONArray("professors");
+
+            // iterate through the JSONArray of professors and add each professor to the mapping
+            int list_length = professor_list.length();
+            for (int j = 0; j < list_length; j++) {
+                JSONObject professor = professor_list.getJSONObject(j);
+                String last_name = (String) professor.get("tLname");
+                String first_name = (String) professor.get("tFname");
+                String score = (String) professor.get("overall_rating");
+                String department = (String) professor.get("tDept");
+                if (!score.equals("N/A")) {
+                    professors.put(first_name + " " + last_name + ", " + department, Double.parseDouble(score));
+                }
+            }
+        }
+        return professors;
+    }
+
+
+    public static void main(String[] args) throws IOException {
+        JSONObject data = request("199");
+        System.out.println(data);
+        System.out.println(getNumberProfessors());
+        System.out.println(getNumberPages());
+        JSONArray profs = data.getJSONArray("professors");
+        System.out.println(profs.length());
+        System.out.println(getProfessors(getNumberPages()));
+
+    }
+}

--- a/src/test/java/gateways/RateMyProfTest.java
+++ b/src/test/java/gateways/RateMyProfTest.java
@@ -1,0 +1,47 @@
+package gateways;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class RateMyProfTest {
+    @Test
+    public void TestRMPgetNumberProfessors() throws IOException {
+        // Test if the RMP getNumberProfessors returns a reasonable value (between 3000 and 5000)
+        int number_professors = RateMyProf.getNumberProfessors();
+        boolean res = number_professors > 3000 && number_professors < 5000;
+        Assertions.assertTrue(res);
+
+    }
+
+    @Test
+    public void TestRMPgetNumberPages() throws IOException {
+        // Test if the RMP getNumberPages returns a value corresponding to the API implementation
+        // Since each page can store a max of 20 professors, the number of pages should be
+        // (numpages (floor division) 2) + 1
+
+        int number_professors = RateMyProf.getNumberProfessors();
+        int number_pages = RateMyProf.getNumberPages();
+        Assertions.assertEquals(number_pages, (number_professors / 20) + 1);
+    }
+
+    @Test
+    public void TestRMPfirstPageProfessors() throws IOException {
+        // Test if the RMP getProfessors returns a HashMap with <= 20 professors and the
+        // first professors last name should start with "A" (alphabetically sorted)
+
+        Map<String, Double> mapping = RateMyProf.getProfessors(1);
+        Object[] keys = mapping.keySet().toArray();
+        String professor = (String) keys[0];
+        String[] split_array = professor.split(" ");
+        String last_name = split_array[1];
+
+        // check name starts with "A"
+        Assertions.assertTrue(last_name.startsWith("A"));
+        Assertions.assertTrue(keys.length <= 20);
+
+    }
+
+}


### PR DESCRIPTION
This implementation should be complete now. Note that when the getProfessors method is called, it returns the mapping of ALL professors, and thus should not be called more than once. This implementation change is due to the fact that it is nearly impossible to know which page the desired professor lies on (there are around 200 pages that change constantly due to RMP user feedback model). Please acknowledge this change in implementation and if there are any conflicts with this change we shall have a meeting. 