### PR TITLE
Small fix to tagger functions, making it less strict because barely a…

### DIFF
--- a/src/main/java/entities/Tagger.java
+++ b/src/main/java/entities/Tagger.java
@@ -113,7 +113,7 @@ public class Tagger {
      * @param session2 other one session being compared
      * @return True if the two sessions are consecutive, False if not
      */
-    private static Boolean consecutiveSessions(Session session1, Session session2) {
+    private static boolean consecutiveSessions(Session session1, Session session2) {
         if ((session1 != null) && (session2 != null) && (session1.getDay() == session2.getDay())) {
             return (session1.getEndTime().equals(session2.getStartTime())) ||
                     (session2.getEndTime().equals(session1.getStartTime()));
@@ -130,7 +130,7 @@ public class Tagger {
      * @param consecutiveCount list with each index representing a day and the value at each index representing
      *                         the number of consecutive courses within that day
      */
-    private static void checkDensity(Session currentSession, Session lastSession, List<Integer> consecutiveCount) {
+    private static void checkDensity(Session lastSession, Session currentSession, List<Integer> consecutiveCount) {
         if (consecutiveSessions(lastSession, currentSession)) {
             int index = currentSession.getDay().getValue();
             consecutiveCount.set(index, consecutiveCount.get(index) + 1);
@@ -152,7 +152,7 @@ public class Tagger {
                 numberOfConsecutiveDays += 1;
             }
         }
-        if (numberOfConsecutiveDays >= 3) {
+        if (numberOfConsecutiveDays >= 2) {
             tags.add("Dense");
         }
     }


### PR DESCRIPTION
…ny timetables have 3 dense days, so changing that to 2 days. Also fixed minor things w/ function headers.

---
name: Pull Request Template
about: Very small change to density tag functions to make it less strict, just changed number of days required to apply tag from 2 to 3
title: ''
labels: ''
assignees: ''

---

**Describe your changes**
Very small change to density tag functions to make it less strict, just changed number of days required to apply tag from 2 to 3, also fixed some function header stuff

**Checklist before requesting a review**
- [x] I have performed a self-review of my code
- [x] I have added thorough tests
- [x] A pull request for this issue does not already exist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, and added JavaDocs
